### PR TITLE
Generate a new site with importmap and Hotwire by default

### DIFF
--- a/lib/skiff/cli.rb
+++ b/lib/skiff/cli.rb
@@ -8,11 +8,16 @@ class Skiff::Cli < Thor
   source_root File.expand_path("templates", __dir__)
 
   desc "new", "Create a new skiff site [SITE_NAME]"
+  option :skip_javascript, type: :boolean, desc: "Skip JavaScript files"
+  option :skip_hotwire, type: :boolean, desc: "Skip Hotwire integration"
   def new(site_name)
     self.destination_root = File.expand_path(site_name)
 
     @site_name = site_name
     @user_name = `whoami`.strip
+    
+    @skip_javascript = options[:skip_javascript]
+    @skip_hotwire = @skip_javascript ? true : options[:skip_hotwire]
 
     eval File.read(File.join(File.dirname(__FILE__), "templates/site.rb"))
   end

--- a/lib/skiff/templates/javascripts/hotwire/application.js
+++ b/lib/skiff/templates/javascripts/hotwire/application.js
@@ -1,0 +1,2 @@
+import "@hotwired/turbo"
+import "controllers"

--- a/lib/skiff/templates/javascripts/hotwire/controllers/application.js
+++ b/lib/skiff/templates/javascripts/hotwire/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/lib/skiff/templates/javascripts/hotwire/controllers/hello_controller.js
+++ b/lib/skiff/templates/javascripts/hotwire/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}

--- a/lib/skiff/templates/javascripts/hotwire/controllers/index.js
+++ b/lib/skiff/templates/javascripts/hotwire/controllers/index.js
@@ -1,0 +1,11 @@
+// Import and register all your controllers from the importmap under controllers/*
+
+import { application } from "controllers/application"
+
+// Eager load all controllers defined in the import map under controllers/**/*_controller
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)
+
+// Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
+// import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
+// lazyLoadControllersFrom("controllers", application)

--- a/lib/skiff/templates/javascripts/importmap.json.tt
+++ b/lib/skiff/templates/javascripts/importmap.json.tt
@@ -1,0 +1,15 @@
+{
+  "imports": {
+    <%- unless @skip_hotwire -%>
+    "application": "/assets/javascripts/application.js",
+    "@hotwired/turbo": "https://ga.jspm.io/npm:@hotwired/turbo@7.3.0/dist/turbo.es2017-esm.js",
+    "@hotwired/stimulus": "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js",
+    "@hotwired/stimulus-loading": "/assets/javascripts/controllers/stimulus-loading.js",
+    
+    "controllers": "/assets/javascripts/controllers/index.js",
+    "controllers/application": "/assets/javascripts/controllers/application.js",
+    
+    "controllers/hello_controller": "/assets/javascripts/controllers/hello_controller.js"
+    <%- end -%>
+  }
+}

--- a/lib/skiff/templates/public/_includes/header.html
+++ b/lib/skiff/templates/public/_includes/header.html
@@ -1,6 +1,0 @@
-<!doctype html>
-<html>
-<head>
-  <title><!--# echo var="title" --></title>
-</head>
-<body>

--- a/lib/skiff/templates/public/_includes/header.html.tt
+++ b/lib/skiff/templates/public/_includes/header.html.tt
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <title><!--# echo var="title" --></title>
+  <%- unless @skip_javascript %>
+  <script type="importmap" data-turbo-track="reload">
+    <!--# include file="/assets/javascripts/importmap.json" -->
+  </script>
+  <%- end -%>
+  <%- unless @skip_hotwire %>
+  <link rel="modulepreload" href="/assets/javascripts/application.js">
+  <script type="module">import "application"</script>
+  <%- end -%>
+</head>
+<body>

--- a/lib/skiff/templates/site.rb
+++ b/lib/skiff/templates/site.rb
@@ -12,6 +12,15 @@ empty_directory_with_keep_file "public/assets/images"
 empty_directory_with_keep_file "public/assets/javascripts"
 empty_directory_with_keep_file "public/assets/stylesheets"
 
+unless @skip_javascript
+  template "javascripts/importmap.json.tt", "public/assets/javascripts/importmap.json"
+end
+
+unless @skip_hotwire
+  directory "javascripts/hotwire", "public/assets/javascripts"
+  get "https://raw.githubusercontent.com/hotwired/stimulus-rails/main/app/assets/javascripts/stimulus-loading.js", "public/assets/javascripts/controllers/stimulus-loading.js"
+end
+
 copy_file "Dockerfile"
 template "README.md.tt", "README.md"
 


### PR DESCRIPTION
This PR adds importmap and Hotwire to the website generated with the `new` command.

### Importmap
Since we can't use `importmap-rails`, the management has to be done manually through the `assets/javascripts/importmap.json` file. This file is included in the `head` of `header.html` by an SSI command.

### Hotwire
The file structure mimics the standard Rails one, with the addition of a `stimulus-loading.js` file pulled from `@hotwired/stimulus-rails` at runtime (any alternatives for this?).

### CLI
To follow the Rails way, this `features` are opt-out. Therefore the `new` command gets two new flags:

- `--skip-hotwire`: Use this flag to skip Hotwire integration, without skipping importmap.
- `--skip-javascript`: Use this flag to skip both importmap and Hotwire.

### Possible improvements

- Managing importmap directly is not ideal. Especially since you have to add each stimulus controller by hand. Is there a similar solution to what we have in Rails that we could use in a no-build environment? Otherwise we could extract some of the `importmap-rails` logic in a standalone executable...
- Even if it works, pulling the `stimulus-loading.js` file from the repo seems a possible source of future issues. Do you think we can make an npm package out of this file? So we can reference it directly in importmap.