### PR TITLE
Fixed Docker alias command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then run `skiff dev` to start the development server.
 
 ```sh
 alias skiff-dev="docker build -t skiff-site . && docker run -it --rm -p 4000:80 -v ./public:/site/public --name skiff-site skiff-site nginx '-g daemon off;'"
-alias skiff="docker run -it --rm -v '${PWD}:/workdir' -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK='/run/host-services/ssh-auth.sock' -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal-skiff:latest"
+alias skiff='docker run -it --rm -v "${PWD}:/workdir" -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/basecamp/kamal-skiff:latest'
 ```
 
 Then run `skiff-dev` to start the development server, and use `skiff [command]` for everything else.


### PR DESCRIPTION
Given `.bashrc` / `.zshrc` files are normally stored in the home fodler (`~`) folder, the `$PWD` variable becomes `~` even if the alias is called from another folder. Wrapping the alias command in single quotes avoids this premature expansion of the variable.

Same as https://github.com/basecamp/kamal-site/pull/36