### PR TITLE
Add .git to dockerignore and clone git repo inside the image

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/skiff/templates/dotfiles/dockerignore
+++ b/lib/skiff/templates/dotfiles/dockerignore
@@ -1,2 +1,3 @@
 # Ignore env file
 /.env
+/.git

--- a/lib/skiff/templates/serve
+++ b/lib/skiff/templates/serve
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+git_init() {
+  git clone --bare $GIT_URL .git
+  git config --unset core.bare
+}
+
 polling_pull() {
   while true; do
     echo "Pulling latest..."
@@ -11,7 +16,7 @@ polling_pull() {
 }
 
 # When GIT_URL is set start polling in the background
-[[ "$GIT_URL" ]] && polling_pull &
+[[ "$GIT_URL" ]] && git_init && polling_pull &
 
 # Start NGINX in the foreground
 nginx -g 'daemon off;'


### PR DESCRIPTION
I had some authentication problems inside the container when building the image with Github Actions. I am guessing it is because some other credentials were pre-setup in the `.git/config` at the time of the docker build. Pulling with my fine-grained token then didn't work anymore inside the container.

Not sure if I am missing something, but currently it seems to depend on your local `.git` folder at the time of the docker build if things work. This PR fixes it by ignoring the `.git/` folder and cloning the bare repo on first boot.