### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/"
+    groups:
+      bundler:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,13 @@ on:
     branches:
       - main
   pull_request:
+permissions: {}
 jobs:
   lint-actions:
     name: GitHub Actions audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -23,6 +26,8 @@ jobs:
           advanced-security: false
 
   tests:
+    permissions:
+      contents: read
     strategy:
       matrix:
         ruby-version:
@@ -37,6 +42,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Ruby
         uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,23 @@ on:
       - main
   pull_request:
 jobs:
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0.5.2
+        with:
+          advanced-security: false
+
   tests:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.11
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.2
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           advanced-security: false
 
@@ -36,10 +36,10 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,8 @@ on:
   release:
     types: [created]
 
+permissions: {}
+
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -20,6 +22,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,12 @@ jobs:
           if [ -z "$INPUT_VALUE" ]; then
             INPUT_VALUE="${GITHUB_REF_NAME}"
           fi
+          # Validate that the tag is a valid Docker tag: 1-128 chars, [A-Za-z0-9_.-] only.
+          if ! printf '%s' "$INPUT_VALUE" | grep -qxE '[A-Za-z0-9_.-]{1,128}'; then
+            echo "Error: Invalid Docker tag value: '$INPUT_VALUE'" >&2
+            echo "Tag must match regex [A-Za-z0-9_.-]{1,128}." >&2
+            exit 1
+          fi
           echo "value=$INPUT_VALUE" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_EVENT_INPUTS_TAGINPUT: ${{ github.event.inputs.tagInput }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,16 +19,16 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
           echo "value=$INPUT_VALUE" >> "$GITHUB_OUTPUT"
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3.3.1
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,11 +36,13 @@ jobs:
       - name: Determine version tag
         id: version-tag
         run: |
-          INPUT_VALUE="${{ github.event.inputs.tagInput }}"
+          INPUT_VALUE="${GITHUB_EVENT_INPUTS_TAGINPUT}"
           if [ -z "$INPUT_VALUE" ]; then
-            INPUT_VALUE="${{ github.ref_name }}"
+            INPUT_VALUE="${GITHUB_REF_NAME}"
           fi
           echo "value=$INPUT_VALUE" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_EVENT_INPUTS_TAGINPUT: ${{ github.event.inputs.tagInput }}
       -
         name: Build and push
         uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3.3.1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,10 +44,10 @@ jobs:
           if [ -z "$INPUT_VALUE" ]; then
             INPUT_VALUE="${GITHUB_REF_NAME}"
           fi
-          # Validate that the tag is a valid Docker tag: 1-128 chars, [A-Za-z0-9_.-] only.
-          if ! printf '%s' "$INPUT_VALUE" | grep -qxE '[A-Za-z0-9_.-]{1,128}'; then
+          # Validate that the tag is a valid Docker tag: 1-128 chars; first char [A-Za-z0-9_], remaining chars [A-Za-z0-9_.-].
+          if ! printf '%s' "$INPUT_VALUE" | grep -qxE '[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}'; then
             echo "Error: Invalid Docker tag value: '$INPUT_VALUE'" >&2
-            echo "Tag must match regex [A-Za-z0-9_.-]{1,128}." >&2
+            echo "Tag must match regex [A-Za-z0-9_][A-Za-z0-9_.-]{0,127} (1-128 chars, cannot start with '.' or '-')." >&2
             exit 1
           fi
           echo "value=$INPUT_VALUE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Add zizmor and actionlint CI job
- Configure dependabot with batched updates and cooldown periods
- Pin all GitHub Actions to SHA hashes
- Fix template-injection, excessive-permissions, and artipacked findings
- Scope all permissions to job-level

## Test plan
- [ ] CI passes (lint-actions job runs clean)
- [ ] Existing test and docker-publish jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)